### PR TITLE
Fixes NPE can be thrown if mime type aren't registered #44

### DIFF
--- a/src/main/java/com/pawandubey/griffin/DirectoryCrawler.java
+++ b/src/main/java/com/pawandubey/griffin/DirectoryCrawler.java
@@ -107,7 +107,7 @@ public class DirectoryCrawler {
                 try {
                     Path resolvedPath = Paths.get(OUTPUT_DIRECTORY).resolve(rootPath.relativize(file));
 
-                    if (Files.probeContentType(file).equals("text/x-markdown") || Files.probeContentType(file).equals("text/markdown")) {
+                    if (file.getFileName().toString().endsWith(".md")) {
 
                         Parsable parsable = createParsable(file);
                         Data.fileQueue.put(parsable);


### PR DESCRIPTION
This commit fixes possibly missing markdown mime-type. It uses file extension '.md' instead.