### PR TITLE
Update handlebars.java version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>com.github.jknack</groupId>
             <artifactId>handlebars</artifactId>
-            <version>2.2.1</version>
+            <version>4.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.zeroturnaround</groupId>


### PR DESCRIPTION
New version of handlebars.java shades libraries inside them self. It reduces amount of dependecies

```
[INFO] +- com.github.jknack:handlebars:jar:2.2.1:compile
[INFO] |  +- org.apache.commons:commons-lang3:jar:3.1:compile
[INFO] |  +- org.antlr:antlr4-runtime:jar:4.5:compile
[INFO] |  +- org.mozilla:rhino:jar:1.7R4:compile
[INFO] |  \- org.slf4j:slf4j-api:jar:1.6.4:compile

[INFO] +- com.github.jknack:handlebars:jar:4.1.2:compile
[INFO] |  \- org.slf4j:slf4j-api:jar:1.7.25:compile
```